### PR TITLE
Fix image overflow in simple themes

### DIFF
--- a/simiki/themes/simple/static/css/style.css
+++ b/simiki/themes/simple/static/css/style.css
@@ -74,6 +74,7 @@ img {
     border: 0;
     vertical-align: middle;
     margin: 0 auto;
+    max-width: 100%;
 }
 
 table {


### PR DESCRIPTION
In default themes Simple, if an image is big enough, this image will overflow.
Add max-width to avoid it.
