### PR TITLE
Fix UI bug

### DIFF
--- a/simiki/themes/simple/static/css/style.css
+++ b/simiki/themes/simple/static/css/style.css
@@ -160,7 +160,7 @@ pre code {
 }
 
 li.pagelist {
-    width: 22em;
+    width: 100%;
     margin-right: 1.5em;
     list-style-type: none;
     white-space: nowrap;


### PR DESCRIPTION
When article's title is very long, the end of the title may be hidden under the 22em width

![1](https://cloud.githubusercontent.com/assets/4951333/5561379/6fd9b2b8-8e0e-11e4-8a02-e2cc64c0ee6b.png)

![2](https://cloud.githubusercontent.com/assets/4951333/5561380/7ce84dd4-8e0e-11e4-9338-7525c5613c4b.png)

