### PR TITLE
add meta info render, when config render:false, return content withou…

### DIFF
--- a/simiki/generators.py
+++ b/simiki/generators.py
@@ -114,7 +114,10 @@ class PageGenerator(BaseGenerator):
 
         meta = self._get_meta(PLAT_LINE_SEP.join(meta_textlist))
         markup_text = PLAT_LINE_SEP.join(markup_textlist)
-        content = self._parse_markdown(markup_text)
+        if meta.get('render', True):
+            content = self._parse_markdown(markup_text)
+        else:
+            content = markup_text
 
         return (meta, content)
 


### PR DESCRIPTION
add meta info render, when config render:false, return content without markdown render.

this patch helps when we need to put some html page into wiki site.

link #47 