### PR TITLE
fix "fab deploy" errors

### DIFF
--- a/simiki/conf_templates/fabfile.py
+++ b/simiki/conf_templates/fabfile.py
@@ -68,8 +68,8 @@ def deploy_rsync(deploy_configs):
 def deploy_git(deploy_configs):
     '''for pages service of such as github/gitcafe ...'''
     with settings(warn_only=True):
-        res = local('which -s ghp-import; echo $?', capture=True)
-        if int(res.strip()):
+        res = local('which ghp-import > /dev/null; echo $?', capture=True)
+        if int(res):
             do_exit('Warning: ghp-import not installed! '
                     'run: `pip install ghp-import`')
     output_dir = configs['destination']

--- a/simiki/conf_templates/fabfile.py
+++ b/simiki/conf_templates/fabfile.py
@@ -68,8 +68,8 @@ def deploy_rsync(deploy_configs):
 def deploy_git(deploy_configs):
     '''for pages service of such as github/gitcafe ...'''
     with settings(warn_only=True):
-        res = local('which ghp-import > /dev/null; echo $?', capture=True)
-        if int(res):
+        res = local('which ghp-import > /dev/null 2>&1; echo $?', capture=True)
+        if int(res.strip()):
             do_exit('Warning: ghp-import not installed! '
                     'run: `pip install ghp-import`')
     output_dir = configs['destination']


### PR DESCRIPTION
when I using the `fab deploy` command to update my site, it happened this errors:
```
[localhost] local: which -s ghp-import; echo $?
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/fabric/main.py", line 749, in main
    *args, **kwargs
  File "/usr/local/lib/python3.4/dist-packages/fabric/tasks.py", line 428, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/fabric/tasks.py", line 175, in run
    return self.wrapped(*args, **kwargs)
  File "/home/ferstar/wiki/fabfile.py", line 145, in deploy
    func(deploy_item)
  File "/home/ferstar/wiki/fabfile.py", line 72, in deploy_git
    if int(res.strip()):
ValueError: invalid literal for int() with base 10: 'Usage: /usr/bin/which [-a] args\n2'
```
so I checked and found the error point.