### PR TITLE
add default Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 
 # Custom
 *.swp
+venv/
+.DS_Store

--- a/simiki/conf_templates/Dockerfile
+++ b/simiki/conf_templates/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:2.7.11
+
+WORKDIR /src
+
+COPY . /src
+RUN pip install simiki
+RUN simiki g
+
+WORKDIR /src/output
+CMD ["python", "-m", "SimpleHTTPServer", "8000"]
+
+EXPOSE 8000

--- a/simiki/conf_templates/Dockerfile
+++ b/simiki/conf_templates/Dockerfile
@@ -6,7 +6,6 @@ COPY . /src
 RUN pip install simiki
 RUN simiki g
 
-WORKDIR /src/output
-CMD ["python", "-m", "SimpleHTTPServer", "8000"]
+CMD ["simiki", "p", "-w", "--host", "0.0.0.0", "--port", "8000"]
 
 EXPOSE 8000

--- a/simiki/initiator.py
+++ b/simiki/initiator.py
@@ -16,6 +16,7 @@ class Initiator(object):
     config_fn = "_config.yml"
     fabfile_fn = "fabfile.py"
     demo_fn = "gettingstarted.md"
+    dockerfile_fn = "Dockerfile"
 
     def __init__(self, config_file, target_path):
         self.config_file = config_file
@@ -50,6 +51,15 @@ class Initiator(object):
         )
         dst_fabfile = os.path.join(self.target_path, self.fabfile_fn)
         self.get_file(src_fabfile, dst_fabfile)
+
+    def get_dockerfile(self):
+        src_dockerfile = os.path.join(
+            self.source_path,
+            self.conf_template_dn,
+            self.dockerfile_fn
+        )
+        dst_dockerfile = os.path.join(self.target_path, self.dockerfile_fn)
+        self.get_file(src_dockerfile, dst_dockerfile)
 
     def get_demo_page(self):
         nohidden_dir = listdir_nohidden(
@@ -89,6 +99,7 @@ class Initiator(object):
                 logging.info("Creating directory: {0}".format(path))
 
         self.get_config_file()
+        self.get_dockerfile()
         self.get_fabfile()
         self.get_demo_page()
         self.get_default_theme(theme_path)


### PR DESCRIPTION
在默认配置文件中添加 Dockerfile

在 init 后会添加的文件加下，以后可以使用 Docker 部署

使用方法如下：

```
docker build . -t wiki
docker run --name wiki-simple -p 6868:8000 wiki
```

打开浏览器 
```
http://localhost:6868
```

Nginx 代理配置
```
server{
        listen 80;
        server_name your_domain;

        location / {
            proxy_pass  http://localhost:6868;

        }
}
```