### PR TITLE
Add filename in error when have invalid metadata, Fix #129 

### DIFF
--- a/simiki/generators.py
+++ b/simiki/generators.py
@@ -200,8 +200,10 @@ class PageGenerator(BaseGenerator):
                 meta_str = match_obj.group('meta')
                 content_str = match_obj.group('body')
             else:
-                raise Exception('extracting page with format error, '
-                                'see <http://simiki.org/docs/metadata.html>')
+                raise Exception(
+                    'extracting page {0} with format error, see '
+                    '<http://simiki.org/docs/metadata.html>'.format(filename)
+                )
 
         return meta_str, content_str
 


### PR DESCRIPTION
Add filename in error when have invalid metadata, so user can know which page has invalid metadata, see #129 