### PR TITLE
docs: fix simple typo, embeded -> embedded

### DIFF
--- a/simiki/generators.py
+++ b/simiki/generators.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Convert Markdown file to html, which is embeded in html template.
+"""Convert Markdown file to html, which is embedded in html template.
 """
 
 from __future__ import (print_function, with_statement, unicode_literals,


### PR DESCRIPTION
There is a small typo in simiki/generators.py.

Should read `embedded` rather than `embeded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md